### PR TITLE
allow flexible header key

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,18 +4,19 @@ const attributeContext = require('./gen/envoy/service/auth/v2/attribute_context_
 const externalAuthService = require('./gen/envoy/service/auth/v2/external_auth_grpc_pb');
 
 module.exports = class Client {
-  constructor(server) {
+  constructor(server, headerKey) {
     this.client = new externalAuthService.AuthorizationClient(
       server,
       grpc.credentials.createInsecure()
     );
+    this.headerKey = headerKey;
   }
 
   async check(authorization) {
     const attributeContextRequestHttp = new attributeContext.AttributeContext.HttpRequest();
     attributeContextRequestHttp
       .getHeadersMap()
-      .set('authorization', authorization);
+      .set(this.headerKey, authorization);
 
     const attributeContextRequest = new attributeContext.AttributeContext.Request();
     attributeContextRequest.setHttp(attributeContextRequestHttp);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const attributeContext = require('./gen/envoy/service/auth/v2/attribute_context_
 const externalAuthService = require('./gen/envoy/service/auth/v2/external_auth_grpc_pb');
 
 module.exports = class Client {
-  constructor(server, headerKey) {
+  constructor(server, headerKey = 'authorization') {
     this.client = new externalAuthService.AuthorizationClient(
       server,
       grpc.credentials.createInsecure()


### PR DESCRIPTION
This PR enables the capability to initialize custom header key when initializing `EnvoyClient`. When second parameter is not passed, it defaults to `authorization`.

Signed-off-by: Try Ajitiono <ballinst@gmail.com>